### PR TITLE
Switch master to swan lake 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ballerina/ballerina:1.2.10
+FROM ballerina/ballerina:swan-lake-alpha1
 
 ADD entrypoint.sh /entrypoint.sh
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -4,4 +4,4 @@ if [ -n "$WORKING_DIR" ]
 then
   cd $WORKING_DIR
 fi
-$BALLERINA_HOME/bin/ballerina $*
+$BALLERINA_HOME/bin/bal $*


### PR DESCRIPTION
## Purpose
> As `ballerina.io` default version is swan lake we need to switch action published version as swan lake. 1.2.x versions can be maintained in a branch [1]

[1] https://github.com/ballerina-platform/ballerina-action/tree/1.2.x